### PR TITLE
Friendly ucl error logging messages

### DIFF
--- a/pylegu/pyLegu.cpp
+++ b/pylegu/pyLegu.cpp
@@ -80,7 +80,28 @@ PYBIND11_MODULE(pylegu, legu_module) {
             nullptr);
 
         if (res != UCL_E_OK) {
-          py::print("[-] Decompression finished with error: {:d}"_s.format(res));
+          std::string s;
+          if (res == UCL_E_INVALID_ARGUMENT)
+            s = "INVALID ARGUMENT";
+          else if (res == UCL_E_OUT_OF_MEMORY)
+            s = "OUT OF MEMORY";
+          else if (res == UCL_E_NOT_COMPRESSIBLE)
+            s = "NOT COMPRESSIBLE";
+          else if (res == UCL_E_INPUT_OVERRUN)
+            s = "INPUT OVERRUN";
+          else if (res == UCL_E_OUTPUT_OVERRUN)
+            s = "OUTPUT OVERRUN";
+          else if (res == UCL_E_LOOKBEHIND_OVERRUN)
+            s = "LOOKBEHIND OVERRUN";
+          else if (res == UCL_E_EOF_NOT_FOUND)
+            s = "EOF NOT FOUND";
+          else if (res == UCL_E_INPUT_NOT_CONSUMED)
+            s = "INPUT NOT CONSUMED";
+          else if (res == UCL_E_OVERLAP_OVERRUN)
+            s = "OVERLAP OVERRUN";
+          else
+            s = "{:d}"_s.format(res);
+          py::print("[-] Decompression finished with error: {:s}"_s.format(s));
         }
 
         return dst;


### PR DESCRIPTION
Improved error logging:
```python
[+] Legu version: 4.1.0.21
[*] /!\ This version may not be supported!
[+] Password is '6mtIjlindZ6M0qgj'
[+] Number of dex files: 1
[+] Unpacking #1 DEX files ...
[+] dex 0 compressed size:   0x119a15
[+] dex 0 uncompressed size: 0x43b444

[+] Unpacking #1 hashmap ...
[+] hashmap 0 compressed size:   0x2c88a
[+] hashmap 0 uncompressed size: 0x5c31c
[-] Decompression finished with error: LOOKBEHIND OVERRUN

[+] Unpacking #1 packed methods ...
[+] packed methods 0 compressed_size:   0xbdb51
[+] packed methods 0 uncompressed_size: 0x1a050a
[-] Decompression finished with error: LOOKBEHIND OVERRUN
```